### PR TITLE
Applied .gitignore to built files

### DIFF
--- a/zeabus/.gitignore
+++ b/zeabus/.gitignore
@@ -1,0 +1,3 @@
+log/
+build/
+install/


### PR DESCRIPTION
I've added .gitignore file to the zeabus package to avoid git to track it's built files.