### PR TITLE
Semicolon bug fixed

### DIFF
--- a/zeabus_sensor/src/imu_node.cpp
+++ b/zeabus_sensor/src/imu_node.cpp
@@ -259,7 +259,7 @@ int main( int argv , char** argc )
     } // loop while for doing in ros system
 
     rclcpp::shutdown();
-    spin_imu.detach()
+    spin_imu.detach();
 
     round = 0; // set init value counter is 0 for start process
     while( imu.port_is_open() ) //


### PR DESCRIPTION
The system tell me like in below img.

So I added that semicolon.

![image](https://user-images.githubusercontent.com/8080856/56457591-3caa6900-63a7-11e9-863b-276e993f3a9f.png)